### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides access to Kuzu databases. This server enables LLMs to inspect database schemas and execute queries on provided kuzu database.
 
+<a href="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server/badge" alt="Kuzu server MCP server" />
+</a>
+
 ## Components
 ### Tools 
 - getSchema

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Model Context Protocol server that provides access to Kuzu databases. This server enables LLMs to inspect database schemas and execute queries on provided kuzu database.
 
 <a href="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server/badge" alt="Kuzu server MCP server" />
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server/badge" alt="Kuzu MCP server badge" />
 </a>
 
 ## Components


### PR DESCRIPTION
This PR adds a badge for the [Kuzu MCP server](https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kuzudb/kuzu-mcp-server/badge" alt="Kuzu server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.